### PR TITLE
Customer details no longer an optional field

### DIFF
--- a/lib/webpay_interswitch/form_builder.rb
+++ b/lib/webpay_interswitch/form_builder.rb
@@ -3,10 +3,12 @@ module WebpayInterswitch
 
     include WebpayInterswitch::Core
 
-    def initialize(txn_ref, amount, html_options, optional_parameters)
+    def initialize(txn_ref, amount, cust_name, cust_id, html_options, optional_parameters)
       @txn_ref = txn_ref
       @amount = amount
       @html_options = html_options
+      @cust_name = cust_name
+      @cust_id = cust_id
       @optional_parameters = optional_parameters
       sanitize_options
     end
@@ -45,6 +47,8 @@ module WebpayInterswitch
         txn_elem_html  = generate_input_field('txn_ref', @txn_ref)
         txn_elem_html += generate_input_field('amount', @amount)
         txn_elem_html += generate_input_field('hash', sha_hash(string_for_hash_param))
+        txn_elem_html += generate_input_field('cust_name', @cust_name)
+        txn_elem_html += generate_input_field('cust_id', @cust_id)
       end
 
       def generate_optional_parameter_elements

--- a/lib/webpay_interswitch/gateway.rb
+++ b/lib/webpay_interswitch/gateway.rb
@@ -7,7 +7,7 @@ module WebpayInterswitch
 
     cattr_accessor :product_id, :pay_item_id, :currency, :site_redirect_url, :mac_key, :test
 
-    TEST_URL = 'https://stageserv.interswitchng.com/test_paydirect/pay'
+    TEST_URL = 'https://sandbox.interswitchng.com/webpay/pay'
 
     LIVE_URL = 'https://webpay.interswitchng.com/paydirect/pay'
 

--- a/lib/webpay_interswitch/transaction_query.rb
+++ b/lib/webpay_interswitch/transaction_query.rb
@@ -22,7 +22,7 @@ module WebpayInterswitch
     # response is populated when a transactions search query is sent.
     attr_accessor :txnref, :resp, :desc, :payRef, :retRef, :cardNum, :amount, :response
 
-    TEST_URL = 'https://stageserv.interswitchng.com/test_paydirect/api/v1/gettransaction.json'
+    TEST_URL = 'https://sandbox.interswitchng.com/webpay/api/v1/gettransaction.json'
 
     LIVE_URL = 'https://webpay.interswitchng.com/paydirect/api/v1/gettransaction.json'
 

--- a/lib/webpay_interswitch/view_helper.rb
+++ b/lib/webpay_interswitch/view_helper.rb
@@ -1,11 +1,10 @@
 module WebpayInterswitch
   module ViewHelper
 
-    def form_for_webpay(txn_ref, amount, html_options={}, optional_parameters={})
-      form_builder = WebpayInterswitch::FormBuilder.new(txn_ref, amount, html_options, optional_parameters)
+    def form_for_webpay(txn_ref, amount, cust_name, cust_id, html_options={}, optional_parameters={})
+      form_builder = WebpayInterswitch::FormBuilder.new(txn_ref, amount, cust_name, cust_id, html_options, optional_parameters)
       WebpayInterswitch::Gateway.new.validate!
       form_builder.generate_webpay_form.html_safe if form_builder.valid?
     end
-
   end
 end


### PR DESCRIPTION
<h3> Scope </h3>
Web Pay are requiring customer_id and customer_name through with their form to get acceptance to their payment gateway. 

<h3> Work done </h3>
Added the elements to the form.

![screen shot 2017-04-17 at 3 48 36 pm](https://cloud.githubusercontent.com/assets/22392943/25090740/5df2c56c-2385-11e7-94aa-6611d3612f6d.png)


<h3> Work to still be done </h3>
If accepted the read me needs updating. 

